### PR TITLE
Remove shebang

### DIFF
--- a/batinfo/__init__.py
+++ b/batinfo/__init__.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # BatInfo
-# A simple Python lib to retreive battery information
+# A simple Python lib to retrieve battery information
 #
 # Copyright (C) 2014 Nicolargo <nicolas@nicolargo.com>
 #
@@ -22,7 +21,7 @@
 __appname__ = "batinfo"
 __version__ = "0.3"
 __author__ = "Nicolas Hennion <nicolas@nicolargo.com>"
-__licence__ = "LGPL"
+__licence__ = "LGPLv3"
 
 __all__ = ['batteries', 'battery', 'Batteries', 'Battery']
 

--- a/batinfo/battery.py
+++ b/batinfo/battery.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Batinfo
-# A simple Python lib to retreive battery information
+# A simple Python lib to retrieve battery information
 #
 # Copyright (C) 2014 Nicolargo <nicolas@nicolargo.com>
 #


### PR DESCRIPTION
This PR removes the shebang to avoid issue while packaging for Py2/Py3. As a module it's usually not executed directly.